### PR TITLE
Add Discord link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,6 @@ Add the `-qmldir` parameter so it finds all dependencies from QML imports.
 
 This adds all the libraries to the folder next to the `.exe` file.
 
+### Contact
 
-
-
+* [Discord](https://discord.gg/jKf9XQE)


### PR DESCRIPTION
I saw on a twitter thread that there was a Discord available:
* https://twitter.com/ChrisuSSBMtG/status/1399584192414076934

> There is a discord link on the bottom of the about page in slippipedia. Dms are also fine.

I assumed "about page" referred to README.md, but after searching through the document I couldn't find it.
I did a search through the entire repository, and saw it was embedded in the qml configuration:
```
$ rg -F 'discordUrl:'
qml/Slippipedia/pages/AboutPage.qml
21:  readonly property string discordUrl: "https://discord.gg/jKf9XQE"
```

I added a link to the Discord to the bottom of the README, I think it might help with support.

It's also understandable if you'd like users to do a bit of work before joining the Discord, which might be your intention - please close this PR if it isn't in line with your goals.